### PR TITLE
commutativity and associativity for products

### DIFF
--- a/src/test/scala/cc/ExampleProofTest.scala
+++ b/src/test/scala/cc/ExampleProofTest.scala
@@ -67,6 +67,20 @@ class ExampleProofTest {
     assert(proof.ty().get == thrm)
   }
 
+  @Test
+  def prod_comm {
+    val thrm = ccc"Π A : ● . Π B : ● . A × B → B × A"
+    val proof = ccc"λ A : ● . λ B : ● . λ p : A × B . λ OUT : ● . λ f : B → A → OUT . f (p B (λ _ : A . λ b : B . b)) (p A (λ a : A . λ _ : B . a))"
+    assertEquals(thrm, proof.ty().get)
+  }
+
+  @Test
+  def prod_assoc {
+    val thrm = ccc"Π A : ● . Π B : ● . Π C : ● . A × B × C → (A × B) × C"
+    val proof = ccc"λ A : ● . λ B : ● . λ C : ● . λ p : A × B × C . λ OUT : ● . λ f : A × B → C → OUT . f (λ OUT0 : ● . λ f0 : A → B → OUT0 . f0 (p A (λ a : A . λ _ : B × C . a)) (p (B × C) (λ _ : A . λ b : B × C . b) B (λ a : B . λ _ : C . a))) (p (B × C) (λ _ : A . λ b : B × C . b) C (λ _ : B . λ b : C . b))"
+    assertEquals(thrm, proof.ty().get)
+  }
+
   //TOOD: the properties of sum types
   //TOOD: forall A, not (not (Lem A))
   //TOOD:  Eq refl, Eq symetric, Eq commutative, Eq allows replacement, Eq transitive,


### PR DESCRIPTION
This project is addictive :joy: 

So I used the following Coq script to generate two test cases:

```                                                                                                                                                                                          
Notation "●" := Prop.
(* the next two do not work for parsing because '.' has a special meaning in Coq *)
Notation "'Π' A : T . B" := (forall A: T, B) (at level 200, right associativity).
Notation "'λ' a : A . b" := (fun a: A => b) (at level 200, right associativity).
Notation "A → B" := (A -> B) (at level 99, right associativity).
Notation "A × B" := (forall C, (A -> B -> C) -> C) (at level 80, right associativity).
(* "only parsing" because parser of calculus-of-constructions does not yet parse these *)
Notation "'fst' p" := (p _ (fun a b => a)) (at level 10, only parsing).
Notation "'snd' p" := (p _ (fun a b => b)) (at level 10, only parsing).
Notation "'pair' a b" := (fun OUT: Prop => fun (f: _ -> _ -> OUT) => f a b)
                             (at level 10, only parsing, a at next level, b at next level).

Set Printing Width 1000.
Check (fun (A B: Prop) (p: A × B) => pair (snd p) (fst p)).

Set Printing Width 1000.
Check (fun (A B C: Prop) (p: A × (B × C)) => pair (pair (fst p) (fst (snd p))) (snd (snd p))).
```

Unfortunately, both tests fail, because calculus-of-constructions and Coq do not infer the same type ("expected" is the type that Coq inferred, and "but was" is the one that calculus-of-constructions inferred):

```
[error] Test cc.ExampleProofTest.prod_comm failed: expected:<
Π A : ● . Π B : ● . Π C : [Π D : ● . Π E : [Π a : A . Π b : B . D] . D] . Π F : ● . Π G : [Π b1 : B . Π a1 : A . F] . F
> but was:<
Π A : ● . Π B : ● . Π C : [Π D : ● . Π E : [Π a : A . Π b : B . D] . D] . Π F : ● . Π G : [Π b1 : B . Π a1 : A . F] . Π b2 : B . Π a2 : A . F
>

[error] Test cc.ExampleProofTest.prod_assoc failed: expected:<
Π A : ● . Π B : ● . Π C : ● . Π D : [Π E : ● . Π F : [Π a : A . Π b : B . Π c : C . E] . E] . Π G : ● . Π H : [Π I : [Π J : ● . Π K : [Π a1 : A . Π b1 : B . J] . J] . Π c1 : C . G] . G
> but was:<
Π A : ● . Π B : ● . Π C : ● . Π D : [Π E : ● . Π F : [Π a : A . Π b : B . Π c : C . E] . E] . Π G : ● . Π H : [Π I : [Π J : ● . Π K : [Π a1 : A . Π b1 : B . J] . J] . Π c1 : C . G] . Π L : [Π M : ● . Π N : [Π a2 : A . Π b2 : B . M] . M] . Π c2 : C . G
>
```

I don't understand what the problem is, and these terms quickly get big and unreadable. Also, it could be that calculus-of-constructions is right and I just screwed up my Coq notations...